### PR TITLE
Allow Mailings#clone to handle mailer gem

### DIFF
--- a/lib/identity-api-client/mailings.rb
+++ b/lib/identity-api-client/mailings.rb
@@ -37,7 +37,7 @@ module IdentityApiClient
       params = {
         'api_token' => client.connection.configuration.options[:api_token]
       }
-      resp = client.post_request("/api/mailings/#{id}/clone", params)
+      resp = client.post_request(route_url("/api/mailings/#{id}/clone"), params)
       if resp.status == 201
         return resp.body['mailing_id']
       else


### PR DESCRIPTION
Just needed to add route_url to the path, like the rest of the methods

This will then add the mailer path if present